### PR TITLE
Travis cgo_enabled cross compilation resolution 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,24 @@ jobs:
       name: Unit Test on Windows
       os: windows
       # script: make unittest
-    - name: Deploy Release
+    - name: Deploy Release osx
       stage: deploy
       os: osx
+      script:
+        - make VERSION=${TRAVIS_TAG}  package-osx
+        - make deploy
+      deploy:
+        provider: releases
+        skip_cleanup: true
+        api_key: "$GITHUB_OAUTH_TOKEN"
+        file: package/*
+        file_glob: true
+        on:
+          branch: master
+          tags: true
+    - name: Deploy Release win/linux
+      stage: deploy
+      os: linux
       script:
         - make VERSION=${TRAVIS_TAG}  package
         - make deploy
@@ -66,4 +81,3 @@ jobs:
         on:
           branch: master
           tags: true
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ go_import_path: github.com/kabanero-io/kabanero-command-line
 services:
   - docker
 
+env:
+  - CGO_ENABLED=1
+
 # skip the default language's install and script steps, we implement job stages instead
 install: skip
 script: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ jobs:
       # script: make unittest
     - name: Deploy Release
       stage: deploy
-      os: linux
+      os: osx
       script:
         - make VERSION=${TRAVIS_TAG}  package
         - make deploy

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ build-linux build-darwin build-windows: ## Build the binary of the respective op
 	GOOS=$(os) GOARCH=amd64 go build -o $(BUILD_PATH)/$(build_binary) -ldflags "-X main.VERSION=$(VERSION)"
 
 .PHONY: package
-package: tar-darwin ## Creates packages for all operating systems and store them in package/ dir
+package: tar-darwin tar-windows tar-linux ## Creates packages for all operating systems and store them in package/ dir
 # package: tar-linux deb-linux rpm-linux tar-darwin brew-darwin tar-windows ## Creates packages for all operating systems and store them in package/ dir
 
 .PHONY: tar-linux

--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,10 @@ build-linux build-darwin build-windows: ## Build the binary of the respective op
 	GOOS=$(os) GOARCH=amd64 go build -o $(BUILD_PATH)/$(build_binary) -ldflags "-X main.VERSION=$(VERSION)"
 
 .PHONY: package
-package: tar-darwin tar-windows tar-linux ## Creates packages for all operating systems and store them in package/ dir
+package: tar-windows tar-linux ## Creates packages for all operating systems and store them in package/ dir
 # package: tar-linux deb-linux rpm-linux tar-darwin brew-darwin tar-windows ## Creates packages for all operating systems and store them in package/ dir
+
+package-osx: tar-darwin 
 
 .PHONY: tar-linux
 tar-linux: build-linux ## Build the linux binary and package it in a .tar file

--- a/Makefile
+++ b/Makefile
@@ -80,9 +80,10 @@ build-linux build-darwin build-windows: ## Build the binary of the respective op
 	GOOS=$(os) GOARCH=amd64 go build -o $(BUILD_PATH)/$(build_binary) -ldflags "-X main.VERSION=$(VERSION)"
 
 .PHONY: package
-package: tar-windows tar-linux ## Creates packages for all operating systems and store them in package/ dir
+package: tar-linux tar-windows ## Creates packages for all operating systems and store them in package/ dir
 # package: tar-linux deb-linux rpm-linux tar-darwin brew-darwin tar-windows ## Creates packages for all operating systems and store them in package/ dir
 
+.PHONY: package-osx
 package-osx: tar-darwin 
 
 .PHONY: tar-linux

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ build-linux build-darwin build-windows: ## Build the binary of the respective op
 	GOOS=$(os) GOARCH=amd64 go build -o $(BUILD_PATH)/$(build_binary) -ldflags "-X main.VERSION=$(VERSION)"
 
 .PHONY: package
-package: tar-linux tar-darwin tar-windows ## Creates packages for all operating systems and store them in package/ dir
+package: tar-darwin ## Creates packages for all operating systems and store them in package/ dir
 # package: tar-linux deb-linux rpm-linux tar-darwin brew-darwin tar-windows ## Creates packages for all operating systems and store them in package/ dir
 
 .PHONY: tar-linux


### PR DESCRIPTION
Adds the CGO_ENABLED=1 env var to fix the vpn resolution problem in issue #98 
Splits the package and travis steps to build the darwin build on osx and linux and windows on linux.
I decided to split the build rather than do all the builds on mac bc travis always has a backlog for osx jobs 
