### PR TITLE
skip microservice request if no url was set

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -31,6 +31,12 @@ var versionCmd = &cobra.Command{
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
+		Info.log("kabanero cli version: ", VERSION)
+
+		if cliConfig.GetString(KabURLKey) == "" {
+			return nil
+		}
+
 		url := getRESTEndpoint("v1/version")
 		resp, err := sendHTTPRequest("GET", url, nil)
 		if err != nil {
@@ -41,8 +47,6 @@ var versionCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		// Info.log("kabanero command version: 0.1.0")
-		Info.log("kabanero cli version: ", VERSION)
 		Info.log("kabanero command line service version: ", versionJSON.Version)
 		return nil
 	},


### PR DESCRIPTION
Currently the version command gives the version for the cli as well as the microservice.
If you run `version` without having logged in, the version command will not give either cli or microservice version.
PR changes to skip the rest call if there is no url set and spit out just the cli version