### PR TITLE
Invalid login url handling 

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -90,6 +90,9 @@ var loginCmd = &cobra.Command{
 			return err
 		}
 		Debug.log("RESPONSE ", kabLoginURL, resp.StatusCode, http.StatusText(resp.StatusCode))
+		if resp.StatusCode == 404 {
+			return errors.New("The url: " + cliConfig.GetString(KabURLKey) + " is not a valid kabanero url")
+		}
 
 		var data JWTResponse
 		err = json.NewDecoder(resp.Body).Decode(&data)


### PR DESCRIPTION
handles 404 from invalid url being passed into the cli. 

Original error from the bad url: 
`Error: invalid character '<' looking for beginning of value`

New error:
`[Error] The url: google.com is not a valid kabanero url`
