### PR TITLE
Osx pkg rename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ jobs:
         - make VERSION=${TRAVIS_TAG}  package-osx
         - make deploy
       before_deploy:
-        - mv package/* "package/newname.tar"
+        - mv package/* "package/kabanero-${TRAVIS_TAG}-macos-amd64.tar"
       deploy:
         provider: releases
         skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,8 @@ jobs:
       script:
         - make VERSION=${TRAVIS_TAG}  package-osx
         - make deploy
+      before_deploy:
+        - mv package/* "package/newname.tar"
       deploy:
         provider: releases
         skip_cleanup: true

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ package-osx: tar-darwin
 tar-linux: build-linux ## Build the linux binary and package it in a .tar file
 .PHONY: tar-darwin
 tar-darwin: build-darwin ## Build the OSX binary and package it in a .tar file
+	mv $(PACKAGE_PATH)/${build_name} $(PACKAGE_PATH)/$(COMMAND)-$(VERSION)-macos-amd64
 tar-linux tar-darwin:
 	cp -p $(BUILD_PATH)/$(build_binary) $(package_binary)
 	tar cfz $(build_name).tar LICENSE README.md $(package_binary)

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,6 @@ package-osx: tar-darwin
 tar-linux: build-linux ## Build the linux binary and package it in a .tar file
 .PHONY: tar-darwin
 tar-darwin: build-darwin ## Build the OSX binary and package it in a .tar file
-	mv $(PACKAGE_PATH)/${build_name}.tar $(PACKAGE_PATH)/$(COMMAND)-$(VERSION)-macos-amd64.tar
 tar-linux tar-darwin:
 	cp -p $(BUILD_PATH)/$(build_binary) $(package_binary)
 	tar cfz $(build_name).tar LICENSE README.md $(package_binary)

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ package-osx: tar-darwin
 tar-linux: build-linux ## Build the linux binary and package it in a .tar file
 .PHONY: tar-darwin
 tar-darwin: build-darwin ## Build the OSX binary and package it in a .tar file
-	mv $(PACKAGE_PATH)/${build_name} $(PACKAGE_PATH)/$(COMMAND)-$(VERSION)-macos-amd64
+	mv $(PACKAGE_PATH)/${build_name}.tar $(PACKAGE_PATH)/$(COMMAND)-$(VERSION)-macos-amd64.tar
 tar-linux tar-darwin:
 	cp -p $(BUILD_PATH)/$(build_binary) $(package_binary)
 	tar cfz $(build_name).tar LICENSE README.md $(package_binary)


### PR DESCRIPTION
adds a predeploy step to travis to rename the darwin binary that gets built 

Test release done on my fork:
https://github.com/s1cyan/kabanero-command-line/releases/tag/v0.3-t.10

Ive added this as a travis step bc when we build locally w go, go still see this as a darwin build, and it is a darwin build but we are renaming it as macos. also it was just easier to add it to travis