### PR TITLE
catch the new 539 error code

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -94,6 +94,15 @@ var loginCmd = &cobra.Command{
 		if resp.StatusCode == 404 {
 			return errors.New("The url: " + cliConfig.GetString(KabURLKey) + " is not a valid kabanero url")
 		}
+		if resp.StatusCode == 539 {
+			message := make(map[string]interface{})
+			err = json.NewDecoder(resp.Body).Decode(&message)
+			if err != nil {
+				return err
+			}
+			fmt.Println(message["message"].(string))
+			return nil
+		}
 
 		var data JWTResponse
 		err = json.NewDecoder(resp.Body).Decode(&data)


### PR DESCRIPTION
now outputs: 
` An error occurred. An error occurred during authentication for user [s1cyan]. The Github configuration is not complete: Github teams or organization have not been defined`

