### PR TITLE
cli services version fix

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -40,7 +40,7 @@ var versionCmd = &cobra.Command{
 		url := getRESTEndpoint("v1/image")
 		resp, err := sendHTTPRequest("GET", url, nil)
 		if err != nil {
-			Info.log("kabanero command line service image: Cannot connect to service, please login")
+			Info.logf("kabanero command line service image: CLI service unavailable, %s", err.Error())
 			return nil
 		}
 		var versionJSON VersionJSON

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -40,7 +40,8 @@ var versionCmd = &cobra.Command{
 		url := getRESTEndpoint("v1/image")
 		resp, err := sendHTTPRequest("GET", url, nil)
 		if err != nil {
-			return err
+			Info.log("kabanero command line service image: Cannot connect to service, please login")
+			return nil
 		}
 		var versionJSON VersionJSON
 		err = json.NewDecoder(resp.Body).Decode(&versionJSON)


### PR DESCRIPTION
Previously output spat out the whole error text if we were not connected to services pod 
new output if cannot connect
```
kabanero cli version: 0.1.0
kabanero command line service image: CLI service unavailable, Login to your kabanero instance
```