### PR TITLE
moves 539 error to be handled in send request function

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -102,15 +102,6 @@ var loginCmd = &cobra.Command{
 		if resp.StatusCode == 404 {
 			return errors.New("The url: " + cliConfig.GetString(KabURLKey) + " is not a valid kabanero url")
 		}
-		if resp.StatusCode == 539 {
-			message := make(map[string]interface{})
-			err = json.NewDecoder(resp.Body).Decode(&message)
-			if err != nil {
-				return err
-			}
-			fmt.Println(message["message"].(string))
-			return nil
-		}
 
 		var data JWTResponse
 		err = json.NewDecoder(resp.Body).Decode(&data)

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -84,6 +84,15 @@ func sendHTTPRequest(method string, url string, jsonBody []byte) (*http.Response
 	if resp.StatusCode == 401 {
 		return nil, errors.New("Your session may have expired or the credentials entered may be invalid")
 	}
+	if resp.StatusCode == 539 {
+		message := make(map[string]interface{})
+		err = json.NewDecoder(resp.Body).Decode(&message)
+		if err != nil {
+			return nil, err
+		}
+		fmt.Println(message["message"].(string))
+		return nil, nil
+	}
 	Debug.log("RESPONSE ", url, resp.StatusCode, http.StatusText(resp.StatusCode))
 	return resp, nil
 }


### PR DESCRIPTION
Previously i only set this to be handled in login, but thought about the possibility of the user getting removed from the group after successfully logging in. Now it is moved to the general send http requestion function that i have in the sync cmd 