### PR TITLE
issue171 stack exception & issue 152 503 handling 

### DIFF
--- a/cmd/deactivate.go
+++ b/cmd/deactivate.go
@@ -49,10 +49,9 @@ This command is useful in a case where you have cloned a stack and customized it
 			return err
 		}
 		deactivateResponse := data["status"]
-		if failureMsg, found := data["exception message"]; found {
-			fmt.Println(failureMsg)
+		if _, found := data["exception message"]; found {
+			fmt.Println(deactivateResponse)
 		}
-		fmt.Println(deactivateResponse)
 		Debug.log(deactivateResponse)
 
 		return nil

--- a/cmd/deactivate.go
+++ b/cmd/deactivate.go
@@ -49,6 +49,9 @@ This command is useful in a case where you have cloned a stack and customized it
 			return err
 		}
 		deactivateResponse := data["status"]
+		if failureMsg, found := data["exception message"]; found {
+			fmt.Println(failureMsg)
+		}
 		fmt.Println(deactivateResponse)
 		Debug.log(deactivateResponse)
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -41,8 +41,10 @@ type StatusStruct struct {
 
 // CommonStackStruct : represents the JSON returned for all the other stacks.
 type CommonStackStruct struct {
-	Name     string
-	Versions []VersionStruct `json:"versions"`
+	Name             string
+	Versions         []VersionStruct `json:"versions"`
+	Status           string
+	ExceptionMessage string `json:"exception message"`
 }
 
 type VersionStruct struct {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -122,14 +122,6 @@ func sendHTTPRequest(method string, url string, jsonBody []byte) (*http.Response
 	return resp, nil
 }
 
-func isExceptionMsg(commonStackResp CommonStackStruct) bool {
-	msg := commonStackResp.ExceptionMessage
-	if msg == "" {
-		return false
-	}
-	return true
-}
-
 // syncCmd represents the sync command
 var syncCmd = &cobra.Command{
 	Use:   "sync",
@@ -172,7 +164,7 @@ var syncCmd = &cobra.Command{
 
 			for i := 0; i < len(data.NewStack); i++ {
 				statusMsg = "added to Kabanero"
-				if isExceptionMsg(data.NewStack[i]) {
+				if data.NewStack[i].ExceptionMessage != "" {
 					statusMsg = data.NewStack[i].Status
 					exceptionMsgs = append(exceptionMsgs, data.NewStack[i].ExceptionMessage)
 				}
@@ -182,7 +174,7 @@ var syncCmd = &cobra.Command{
 			}
 			for i := 0; i < len(data.ActivateStack); i++ {
 				statusMsg = "inactive ==> active"
-				if isExceptionMsg(data.ActivateStack[i]) {
+				if data.ActivateStack[i].ExceptionMessage != "" {
 					statusMsg = data.ActivateStack[i].Status
 					exceptionMsgs = append(exceptionMsgs, data.ActivateStack[i].ExceptionMessage)
 				}
@@ -198,7 +190,7 @@ var syncCmd = &cobra.Command{
 			}
 			for i := 0; i < len(data.ObsoleteStack); i++ {
 				statusMsg = "deleted"
-				if isExceptionMsg(data.ObsoleteStack[i]) {
+				if data.ObsoleteStack[i].ExceptionMessage != "" {
 					statusMsg = data.ObsoleteStack[i].Status
 					exceptionMsgs = append(exceptionMsgs, data.ObsoleteStack[i].ExceptionMessage)
 				}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -78,13 +78,18 @@ func sendHTTPRequest(method string, url string, jsonBody []byte) (*http.Response
 
 	resp, err = client.Do(req)
 	if err != nil {
+		data := make(map[string]interface{})
+		err = json.NewDecoder(resp.Body).Decode(&data)
+		fmt.Println("----------", data)
 		return resp, errors.New(err.Error())
 	}
 	if resp.StatusCode == 503 {
 		data := make(map[string]interface{})
 		err = json.NewDecoder(resp.Body).Decode(&data)
+		fmt.Println("----------", data)
+
 		if err != nil {
-			return resp, errors.New(cliConfig.GetString(KabURLKey) + " is unreachable")
+			return resp, errors.New(cliConfig.GetString(KabURLKey) + " is unreachable." + resp.Status)
 		}
 
 	}
@@ -116,6 +121,14 @@ func sendHTTPRequest(method string, url string, jsonBody []byte) (*http.Response
 	return resp, nil
 }
 
+func isExceptionMsg(commonStackResp CommonStackStruct) bool {
+	msg := commonStackResp.ExceptionMessage
+	if msg == "" {
+		return false
+	}
+	return true
+}
+
 // syncCmd represents the sync command
 var syncCmd = &cobra.Command{
 	Use:   "sync",
@@ -125,6 +138,7 @@ var syncCmd = &cobra.Command{
 	Modifications to the curated stacks may be slow to replicate in git hub and therefore may not be reflected immediately in KABANERO LIST or SYNC display output
 	`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+
 		url := getRESTEndpoint("v1/stacks")
 		resp, err := sendHTTPRequest("PUT", url, nil)
 		if err != nil {
@@ -152,14 +166,28 @@ var syncCmd = &cobra.Command{
 			fmt.Fprintf(tWriter, "\n%s\t%s\t%s", KabStacksHeader, "Version", "Status")
 			fmt.Fprintf(tWriter, "\n%s\t%s\t%s", strings.Repeat("-", len(KabStacksHeader)), "-------", "------")
 
+			var statusMsg string
+			var exceptionMsgs []string
+
 			for i := 0; i < len(data.NewStack); i++ {
+				statusMsg = "added to Kabanero"
+				if isExceptionMsg(data.NewStack[i]) {
+					statusMsg = data.NewStack[i].Status
+					exceptionMsgs = append(exceptionMsgs, data.NewStack[i].ExceptionMessage)
+				}
 				for j := 0; j < len(data.NewStack[i].Versions); j++ {
-					fmt.Fprintf(tWriter, "\n%s\t%s\t%s", data.NewStack[i].Name, data.NewStack[i].Versions[j].Version, "added to Kabanero")
+					fmt.Fprintf(tWriter, "\n%s\t%s\t%s", data.NewStack[i].Name, data.NewStack[i].Versions[j].Version, statusMsg)
 				}
 			}
 			for i := 0; i < len(data.ActivateStack); i++ {
+				statusMsg = "inactive ==> active"
+				if isExceptionMsg(data.ActivateStack[i]) {
+					statusMsg = data.ActivateStack[i].Status
+					exceptionMsgs = append(exceptionMsgs, data.ActivateStack[i].ExceptionMessage)
+				}
+
 				for j := 0; j < len(data.ActivateStack[i].Versions); j++ {
-					fmt.Fprintf(tWriter, "\n%s\t%s\t%s", data.ActivateStack[i].Name, data.ActivateStack[i].Versions[j].Version, "inactive ==> active")
+					fmt.Fprintf(tWriter, "\n%s\t%s\t%s", data.ActivateStack[i].Name, data.ActivateStack[i].Versions[j].Version, statusMsg)
 				}
 			}
 			for i := 0; i < len(data.KabStack); i++ {
@@ -168,14 +196,24 @@ var syncCmd = &cobra.Command{
 				}
 			}
 			for i := 0; i < len(data.ObsoleteStack); i++ {
+				statusMsg = "deleted"
+				if isExceptionMsg(data.ObsoleteStack[i]) {
+					statusMsg = data.ObsoleteStack[i].Status
+					exceptionMsgs = append(exceptionMsgs, data.ObsoleteStack[i].ExceptionMessage)
+				}
 				for j := 0; j < len(data.ObsoleteStack[i].Versions); j++ {
-					fmt.Fprintf(tWriter, "\n%s\t%s\t%s", data.ObsoleteStack[i].Name, data.ObsoleteStack[i].Versions[j].Version, "deleted")
+					fmt.Fprintf(tWriter, "\n%s\t%s\t%s", data.ObsoleteStack[i].Name, data.ObsoleteStack[i].Versions[j].Version, statusMsg)
 				}
 			}
 
 			fmt.Fprintln(tWriter)
 			tWriter.Flush()
+
+			for i := 0; i < len(exceptionMsgs); i++ {
+				fmt.Println(exceptionMsgs[i])
+			}
 		}
+
 		return nil
 	},
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -86,8 +86,9 @@ func sendHTTPRequest(method string, url string, jsonBody []byte) (*http.Response
 	if resp.StatusCode == 503 {
 		data := make(map[string]interface{})
 		err = json.NewDecoder(resp.Body).Decode(&data)
-		fmt.Println("----------", data)
-
+		if data["message"] != "" {
+			fmt.Println(data["message"])
+		}
 		if err != nil {
 			return resp, errors.New(cliConfig.GetString(KabURLKey) + " is unreachable." + resp.Status)
 		}

--- a/vendor/github.com/hashicorp/hcl/decoder.go
+++ b/vendor/github.com/hashicorp/hcl/decoder.go
@@ -505,7 +505,7 @@ func expandObject(node ast.Node, result reflect.Value) ast.Node {
 	// we need to un-flatten the ast enough to decode
 	newNode := &ast.ObjectItem{
 		Keys: []*ast.ObjectKey{
-			&ast.ObjectKey{
+			{
 				Token: keyToken,
 			},
 		},

--- a/vendor/github.com/spf13/afero/memmap.go
+++ b/vendor/github.com/spf13/afero/memmap.go
@@ -269,7 +269,7 @@ func (m *MemMapFs) RemoveAll(path string) error {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	for p, _ := range m.getData() {
+	for p := range m.getData() {
 		if strings.HasPrefix(p, path) {
 			m.mu.RUnlock()
 			m.mu.Lock()

--- a/vendor/github.com/spf13/viper/viper.go
+++ b/vendor/github.com/spf13/viper/viper.go
@@ -1702,7 +1702,7 @@ func (v *Viper) flattenAndMergeMap(shadow map[string]bool, m map[string]interfac
 func (v *Viper) mergeFlatMap(shadow map[string]bool, m map[string]interface{}) map[string]bool {
 	// scan keys
 outer:
-	for k, _ := range m {
+	for k := range m {
 		path := strings.Split(k, v.keyDelim)
 		// scan intermediate paths
 		var parentKey string

--- a/vendor/golang.org/x/text/unicode/cldr/cldr.go
+++ b/vendor/golang.org/x/text/unicode/cldr/cldr.go
@@ -117,7 +117,7 @@ func (cldr *CLDR) Supplemental() *SupplementalData {
 func (cldr *CLDR) Locales() []string {
 	loc := []string{"root"}
 	hasRoot := false
-	for l, _ := range cldr.locale {
+	for l := range cldr.locale {
 		if l == "root" {
 			hasRoot = true
 			continue

--- a/vendor/golang.org/x/text/unicode/cldr/resolve.go
+++ b/vendor/golang.org/x/text/unicode/cldr/resolve.go
@@ -289,7 +289,7 @@ var distinguishing = map[string][]string{
 	"mzone":      nil,
 	"from":       nil,
 	"to":         nil,
-	"type": []string{
+	"type": {
 		"abbreviationFallback",
 		"default",
 		"mapping",
@@ -527,7 +527,7 @@ func (cldr *CLDR) inheritSlice(enc, v, parent reflect.Value) (res reflect.Value,
 		}
 	}
 	keys := make([]string, 0, len(index))
-	for k, _ := range index {
+	for k := range index {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)

--- a/vendor/golang.org/x/text/unicode/cldr/slice.go
+++ b/vendor/golang.org/x/text/unicode/cldr/slice.go
@@ -83,7 +83,7 @@ func (s Slice) Group(fn func(e Elem) string) []Slice {
 		m[key] = append(m[key], vi)
 	}
 	keys := []string{}
-	for k, _ := range m {
+	for k := range m {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)

--- a/vendor/golang.org/x/text/unicode/norm/maketables.go
+++ b/vendor/golang.org/x/text/unicode/norm/maketables.go
@@ -242,7 +242,7 @@ func compactCCC() {
 		m[c.ccc] = 0
 	}
 	cccs := []int{}
-	for v, _ := range m {
+	for v := range m {
 		cccs = append(cccs, int(v))
 	}
 	sort.Ints(cccs)

--- a/vendor/gopkg.in/yaml.v2/readerc.go
+++ b/vendor/gopkg.in/yaml.v2/readerc.go
@@ -95,7 +95,7 @@ func yaml_parser_update_buffer(parser *yaml_parser_t, length int) bool {
 
 	// [Go] This function was changed to guarantee the requested length size at EOF.
 	// The fact we need to do this is pretty awful, but the description above implies
-	// for that to be the case, and there are tests 
+	// for that to be the case, and there are tests
 
 	// If the EOF flag is set and the raw buffer is empty, do nothing.
 	if parser.eof && parser.raw_buffer_pos == len(parser.raw_buffer) {

--- a/vendor/gopkg.in/yaml.v2/resolve.go
+++ b/vendor/gopkg.in/yaml.v2/resolve.go
@@ -180,7 +180,7 @@ func resolve(tag string, in string) (rtag string, out interface{}) {
 					return yaml_INT_TAG, uintv
 				}
 			} else if strings.HasPrefix(plain, "-0b") {
-				intv, err := strconv.ParseInt("-" + plain[3:], 2, 64)
+				intv, err := strconv.ParseInt("-"+plain[3:], 2, 64)
 				if err == nil {
 					if true || intv == int64(int(intv)) {
 						return yaml_INT_TAG, int(intv)

--- a/vendor/gopkg.in/yaml.v2/sorter.go
+++ b/vendor/gopkg.in/yaml.v2/sorter.go
@@ -52,7 +52,7 @@ func (l keyList) Less(i, j int) bool {
 		var ai, bi int
 		var an, bn int64
 		if ar[i] == '0' || br[i] == '0' {
-			for j := i-1; j >= 0 && unicode.IsDigit(ar[j]); j-- {
+			for j := i - 1; j >= 0 && unicode.IsDigit(ar[j]); j-- {
 				if ar[j] != '0' {
 					an = 1
 					bn = 1


### PR DESCRIPTION
for issue #152  
handles the 503 operator error 
output looks like 
```
The Kabanero operator is not ready, error message: null
Error: EOF
Usage:
  kabanero list  [flags]

Flags:
  -h, --help   help for list

Global Flags:
  -v, --verbose   Turns on debug output and logging to a file in $HOME/.kabanero/logs

[Error] EOF
``` 
for #171 
for sync failed to activate, now shows the failed status and the reasons for why underneath the table
```
claudias-mbp kabanero-command-line =>./build/kabanero sync

Kabanero Instance Stacks 	Version	Status
-------------------------	-------	------
java-microprofile		0.2.21	added to Kabanero
java-spring-boot2		0.3.21	failed to activate
nodejs-express			0.2.8	failed to activate
nodejs-loopback			0.1.8	failed to activate
stack name: java-spring-boot2, Internal Server Error, cause: null
stack name: nodejs-express, Internal Server Error, cause: null
stack name: nodejs-loopback, Internal Server Error, cause: null
```
for deactivate - if it failed to deactivate 
```
 claudias-mbp kabanero-command-line =>./build/kabanero deactivate java-spring-boot2 0.3.18
Stack name: java-spring-boot2 version: 0.3.18 failed to deactivate, exception message: Internal Server Error
```