### PR TITLE
Error overhaul

### DIFF
--- a/cmd/deactivate.go
+++ b/cmd/deactivate.go
@@ -17,7 +17,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -51,7 +50,8 @@ This command is useful in a case where you have cloned a stack and customized it
 		}
 		deactivateResponse := data["status"]
 		if deactivateResponse == nil {
-			return errors.New("no status with deactivate response")
+			// return errors.New("no status with deactivate response")
+			return err
 		}
 		Debug.log(deactivateResponse)
 		fmt.Println(deactivateResponse)

--- a/cmd/deactivate.go
+++ b/cmd/deactivate.go
@@ -53,10 +53,8 @@ This command is useful in a case where you have cloned a stack and customized it
 		if deactivateResponse == nil {
 			return errors.New("no status with deactivate response")
 		}
-		// if _, found := data["exception message"]; found {
+		Debug.log(deactivateResponse)
 		fmt.Println(deactivateResponse)
-		// }
-		// Debug.log(deactivateResponse)
 
 		return nil
 	},

--- a/cmd/deactivate.go
+++ b/cmd/deactivate.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -49,10 +50,13 @@ This command is useful in a case where you have cloned a stack and customized it
 			return err
 		}
 		deactivateResponse := data["status"]
-		if _, found := data["exception message"]; found {
-			fmt.Println(deactivateResponse)
+		if deactivateResponse == nil {
+			return errors.New("no status with deactivate response")
 		}
-		Debug.log(deactivateResponse)
+		// if _, found := data["exception message"]; found {
+		fmt.Println(deactivateResponse)
+		// }
+		// Debug.log(deactivateResponse)
 
 		return nil
 	},


### PR DESCRIPTION
Most error codes moved to a map of codes to be handled in one block.
Debug formatting fixed
Some fixes to use os.exit instead of error to refrain from getting the usability [Error] 