### PR TITLE
Removes newline error, sync grammar, login -h cleanup 

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -41,7 +41,7 @@ func parseKabURL(url string) string {
 
 // loginCmd represents the login command
 var loginCmd = &cobra.Command{
-	Use:   "login kabanero-url -u Github userid /n PASSWORDPROMPT:GitHub Password|PAT",
+	Use:   "login kabanero-cli-url -u Github userid \n  At the password prompt, enter your GitHub Password/PAT",
 	Short: "Will authenticate you to a Kabanero instance",
 	Long: `
 	Logs in to a Kabanero instance using Github credentials, and stores a temporary access token for subsequent command line calls.

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -164,7 +164,7 @@ var syncCmd = &cobra.Command{
 		tWriter := new(tabwriter.Writer)
 		tWriter.Init(os.Stdout, 0, 8, 0, '\t', 0)
 		if len(data.NewStack) == 0 && (len(data.KabStack) == 0) && len(data.ObsoleteStack) == 0 && len(data.CuratedStack) == 0 && len(data.ActivateStack) == 0 {
-			syncedOutput := KabStacksHeader + " is already synchronized with the " + GHStacksHeader
+			syncedOutput := KabStacksHeader + " are already synchronized with the " + GHStacksHeader
 			fmt.Println(strings.ToLower(syncedOutput))
 		} else {
 			fmt.Fprintf(tWriter, "\n%s\t%s\t%s", KabStacksHeader, "Version", "Status")

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -123,7 +123,6 @@ func sendHTTPRequest(method string, url string, jsonBody []byte) (*http.Response
 		if message["message"] == nil {
 			return resp, errors.New("No message in response")
 		}
-		fmt.Println()
 		Debug.logf("HTTP Status %d : %s", resp.StatusCode, message["message"].(string))
 		fmt.Println(message["message"].(string))
 		os.Exit(3)


### PR DESCRIPTION
1. Errors with os.exit had a blank newline and then the error. Removed that


2. `Kab Collections  ~is~ are already synchronized `

3. 
from: 
`kabanero login kabanero-url -u Github userid /n PASSWORDPROMPT:GitHub Password|PAT [flags]`

to: 
```
Usage:
  kabanero login kabanero-cli-url -u Github userid 
  At the password prompt, enter your GitHub Password/PAT [flags]
```
