### PR TITLE
Vpn segfault fix 

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -94,9 +94,13 @@ func sendHTTPRequest(method string, url string, jsonBody []byte) (*http.Response
 
 	resp, err = client.Do(req)
 	if err != nil {
-		data := make(map[string]interface{})
-		err = json.NewDecoder(resp.Body).Decode(&data)
-		fmt.Println("----------", data)
+		fmt.Println("No response from url: " + cliConfig.GetString(KabURLKey))
+		// data := make(map[string]interface{})
+		// if resp == nil {
+		// 	fmt.Println("No response")
+		// }
+		// err = json.NewDecoder(resp.Body).Decode(&data)
+		// fmt.Println("----------", data)
 		return resp, errors.New(err.Error())
 	}
 	if verboseHTTP {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -95,12 +95,7 @@ func sendHTTPRequest(method string, url string, jsonBody []byte) (*http.Response
 	resp, err = client.Do(req)
 	if err != nil {
 		fmt.Println("No response from url: " + cliConfig.GetString(KabURLKey))
-		// data := make(map[string]interface{})
-		// if resp == nil {
-		// 	fmt.Println("No response")
-		// }
-		// err = json.NewDecoder(resp.Body).Decode(&data)
-		// fmt.Println("----------", data)
+		Debug.log("No response from url (check vpn): " + cliConfig.GetString(KabURLKey))
 		return resp, errors.New(err.Error())
 	}
 	if verboseHTTP {


### PR DESCRIPTION
No longer tries to parse out data from empty URL response. To fix the segfault error that happened when trying to run commands without putting up the VPN to get to the Kabanero endpoint.

Adds debug message 

Previous output:

```
claudias-mbp kabanero-command-line =>./build/kabanero logout
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x14215ba]
goroutine 1 [running]:
github.com/kabanero-io/kabanero-command-line/cmd.sendHTTPRequest(0x1516350, 0x4, 0xc0000ba460, 0x49, 0x0, 0x0, 0x0, 0x1516ccb, 0x6, 0xc0000ba460)
	/Users/claudia.yanibm.com/go/src/github.com/kabanero-io/kabanero-command-line/cmd/sync.go:98 +0xe6a
github.com/kabanero-io/kabanero-command-line/cmd.glob..func6(0x18e7660, 0x190ce18, 0x0, 0x0, 0x0, 0x0)
	/Users/claudia.yanibm.com/go/src/github.com/kabanero-io/kabanero-command-line/cmd/logout.go:32 +0xed
github.com/kabanero-io/kabanero-command-line/vendor/github.com/spf13/cobra.(*Command).execute(0x18e7660, 0x190ce18, 0x0, 0x0, 0x18e7660, 0x190ce18)
	/Users/claudia.yanibm.com/go/src/github.com/kabanero-io/kabanero-command-line/vendor/github.com/spf13/cobra/command.go:762 +0x460
github.com/kabanero-io/kabanero-command-line/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x18e6ce0, 0x18ac780, 0xc000000180, 0xc0000f9f50)
	/Users/claudia.yanibm.com/go/src/github.com/kabanero-io/kabanero-command-line/vendor/github.com/spf13/cobra/command.go:852 +0x2ea
github.com/kabanero-io/kabanero-command-line/vendor/github.com/spf13/cobra.(*Command).Execute(...)
	/Users/claudia.yanibm.com/go/src/github.com/kabanero-io/kabanero-command-line/vendor/github.com/spf13/cobra/command.go:800
github.com/kabanero-io/kabanero-command-line/cmd.Execute(0x15b2ca0, 0x5)
	/Users/claudia.yanibm.com/go/src/github.com/kabanero-io/kabanero-command-line/cmd/root.go:170 +0x56
main.main()
```

New output 
```
claudias-mbp kabanero-command-line =>./build/kabanero login -u sample
Password:No response from url: <url>
Error: Post <url>login: dial tcp: lookup <url> no such host
Usage:
  kabanero login kabanero-cli-url -u Github userid 
  At the password prompt, enter your GitHub Password/PAT [flags]

Examples:

	# login with Github userid and password:
	kabanero login my.kabaneroInstance.io -u myGithubID 
	# login with previously used url Github userid and PAT:
	kabanero login -u myGithubID 
	

Flags:
  -h, --help              help for login
  -u, --username string   github username

Global Flags:
  -v, --verbose   Turns on debug output and logging to a file in $HOME/.kabanero/logs. If installed with brew the file is in ~/Library/Logs/kabanero/

[Error] Post <url>/login: dial tcp: lookup <url>: no such host
```
**Note i will resolve the usage error block in the next pull request for the issue to handle the usability error**