### PR TITLE
Check if services is below 0.6.0

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -58,7 +58,7 @@ func is06Compatible() bool {
 	servicesVersion2ndVal, _ := strconv.Atoi(strings.Split(servicesVersion, ".")[1])
 	if servicesVersion2ndVal < 6 {
 
-		fmt.Printf("\nYour current CLI version (%s) is incompatible with the command line service image (%s). Please upgrade your Kabanero service to  version 0.6.0 or greater, or get a version of the CLI that matches the service image\n", VERSION, servicesVersion)
+		fmt.Printf("\nYour current CLI version (%s) is incompatible with the command line service image (%s). Please upgrade your Kabanero service to version 0.6.0 or greater, or get a version of the CLI that matches the service image\n", VERSION, servicesVersion)
 		return false
 	}
 	fmt.Println(servicesVersion)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -138,7 +138,7 @@ var loginCmd = &cobra.Command{
 			messageAndExit("Unable to validate user: " + username + " to " + cliConfig.GetString(KabURLKey))
 		}
 
-		if !developerMode && !is06Compatible() {
+		if !is06Compatible() {
 
 			url := getRESTEndpoint("logout")
 			resp, err := sendHTTPRequest("POST", url, nil)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -56,7 +56,7 @@ func is06Compatible() bool {
 	servicesVersion2ndVal, _ := strconv.Atoi(strings.Split(servicesVersion, ".")[1])
 	if servicesVersion2ndVal < 6 {
 
-		fmt.Printf("\nYour current CLI version (%s) is incompatible with the command line service image (%s). Please upgrade your Kabanero service to  version 0.6.0 or greater, or revert to cli version 0.4.0.", VERSION, servicesVersion)
+		fmt.Printf("\nYour current CLI version (%s) is incompatible with the command line service image (%s). Please upgrade your Kabanero service to  version 0.6.0 or greater, or get a version of the CLI that matches the service image\n", VERSION, servicesVersion)
 		return false
 	}
 	fmt.Println(servicesVersion)
@@ -136,7 +136,7 @@ var loginCmd = &cobra.Command{
 			messageAndExit("Unable to validate user: " + username + " to " + cliConfig.GetString(KabURLKey))
 		}
 
-		if developerMode == false && !is06Compatible() {
+		if !developerMode && !is06Compatible() {
 
 			url := getRESTEndpoint("logout")
 			resp, err := sendHTTPRequest("POST", url, nil)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -62,7 +62,6 @@ func is06Compatible() bool {
 		fmt.Printf("\nYour current CLI version (%s) is incompatible with the command line service image (%s). Please upgrade your command line service to version 0.6.0 or greater, or get a version of the CLI that matches the service image\n", VERSION, servicesVersion)
 		return false
 	}
-	fmt.Println(servicesVersion)
 	return true
 }
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -51,8 +51,10 @@ func is06Compatible() bool {
 	if err != nil {
 		return false
 	}
-	versionJSON.Image = "kabanero/kabanero-command-line-services:0.4.0"
 	servicesVersion := strings.Split(versionJSON.Image, ":")[1]
+	if servicesVersion == "latest" {
+		return true
+	}
 	servicesVersion2ndVal, _ := strconv.Atoi(strings.Split(servicesVersion, ".")[1])
 	if servicesVersion2ndVal < 6 {
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -49,6 +49,7 @@ func is06Compatible() bool {
 	var versionJSON VersionJSON
 	err = json.NewDecoder(resp.Body).Decode(&versionJSON)
 	if err != nil {
+		messageAndExit("Error decoding version response for compatibility check") //this will osexit, not return
 		return false
 	}
 	servicesVersion := strings.Split(versionJSON.Image, ":")[1]
@@ -58,7 +59,7 @@ func is06Compatible() bool {
 	servicesVersion2ndVal, _ := strconv.Atoi(strings.Split(servicesVersion, ".")[1])
 	if servicesVersion2ndVal < 6 {
 
-		fmt.Printf("\nYour current CLI version (%s) is incompatible with the command line service image (%s). Please upgrade your Kabanero service to version 0.6.0 or greater, or get a version of the CLI that matches the service image\n", VERSION, servicesVersion)
+		fmt.Printf("\nYour current CLI version (%s) is incompatible with the command line service image (%s). Please upgrade your command line service to version 0.6.0 or greater, or get a version of the CLI that matches the service image\n", VERSION, servicesVersion)
 		return false
 	}
 	fmt.Println(servicesVersion)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,7 +25,6 @@ var (
 	//dryrun          bool
 	verbose         bool
 	verboseHTTP     bool
-	developerMode   bool
 	klogInitialized = false
 	KabURLKey       = "KABURL"
 )

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,8 +41,7 @@ func homeDir() string {
 var rootCmd = &cobra.Command{
 	Use:   "kabanero",
 	Short: "This repo defines a command line interface used by the enterprise, solution, or application architect who defines and manages the kabanero stacks that are used by developers to create governed applications for their business.",
-	Long: `**kabanero** is a command line interface for managing the stacks in a Kabanero 
-environment, as well as to on-board the people that will use 
+	Long: `**kabanero** is a command line interface for managing the stacks in a Kabanero environment, as well as to on-board the people that will use 
 the environment to build applications.
 
 Before using the cli please configure the github authorization for the cli service. Steps can be found in the following documentation: https://kabanero.io/docs/ref/general/configuration/github-authorization.html

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,7 +66,6 @@ func init() {
 	// Added for logging
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Turns on debug output and logging to a file in $HOME/.kabanero/logs. If installed with brew the file is in ~/Library/Logs/kabanero/")
 	rootCmd.PersistentFlags().BoolVarP(&verboseHTTP, "debug http", "x", false, "Turns on debug output for http request/responses")
-	rootCmd.PersistentFlags().BoolVarP(&developerMode, "developer mode", "d", false, "Bypasses certain blocks in the CLI")
 	err := rootCmd.PersistentFlags().MarkHidden("debug http")
 	if err != nil {
 		fmt.Fprintln(os.Stdout, "err with MarkHidden")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ var (
 	//dryrun          bool
 	verbose         bool
 	verboseHTTP     bool
+	developerMode   bool
 	klogInitialized = false
 	KabURLKey       = "KABURL"
 )
@@ -65,6 +66,7 @@ func init() {
 	// Added for logging
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Turns on debug output and logging to a file in $HOME/.kabanero/logs. If installed with brew the file is in ~/Library/Logs/kabanero/")
 	rootCmd.PersistentFlags().BoolVarP(&verboseHTTP, "debug http", "x", false, "Turns on debug output for http request/responses")
+	rootCmd.PersistentFlags().BoolVarP(&developerMode, "developer mode", "d", false, "Bypasses certain blocks in the CLI")
 	err := rootCmd.PersistentFlags().MarkHidden("debug http")
 	if err != nil {
 		fmt.Fprintln(os.Stdout, "err with MarkHidden")

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -120,7 +120,7 @@ func sendHTTPRequest(method string, url string, jsonBody []byte) (*http.Response
 		message := make(map[string]interface{})
 		err = json.NewDecoder(resp.Body).Decode(&message)
 		if err != nil {
-			messageAndExit("Error decoding http response")
+			messageAndExit("No Response, check CLI service status")
 		}
 		if message["message"] == nil {
 			messageAndExit("No message in http response")


### PR DESCRIPTION
This version compatibility check only checks if the services version is below 0.6.0 for the big collections to stacks change. This is **not** a more nuanced compatibility check that goes by specific versions 

If the service is on latest, which only the developers should be on it skips the incompatibility warning 

**What does the change look like:**

```
claudias-mbp kabanero-command-line =>./build/kabanero login -u s1cyan
Password:

Your current CLI version (0.1.0) is incompatible with the command line service image (0.4.0). Please upgrade your Kabanero service to  version 0.6.0 or greater, or get a version of the CLI that matches the service image. 
```