### PR TITLE
fixes 060 version check to also check if first value is 0

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -56,8 +56,9 @@ func is06Compatible() bool {
 	if servicesVersion == "latest" {
 		return true
 	}
+	servicesVersion1stVal, _ := strconv.Atoi(strings.Split(servicesVersion, ".")[0])
 	servicesVersion2ndVal, _ := strconv.Atoi(strings.Split(servicesVersion, ".")[1])
-	if servicesVersion2ndVal < 6 {
+	if servicesVersion2ndVal < 6 && servicesVersion1stVal == 0 {
 
 		fmt.Printf("\nYour current CLI version (%s) is incompatible with the command line service image (%s). Please upgrade your command line service to version 0.6.0 or greater, or get a version of the CLI that matches the service image\n", VERSION, servicesVersion)
 		return false


### PR DESCRIPTION
No visible changes in this PR.
Just adds a check if the first digit of the cli service version is 0. Before didn't check and that would have caused lockout failures for anything that came out in future 1.x.x versions 