### PR TITLE
Initial kabanero summary change 

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,7 +43,7 @@ var rootCmd = &cobra.Command{
 	Short: "This repo defines a command line interface used by the enterprise, solution, or application architect who defines and manages the kabanero stacks that are used by developers to create governed applications for their business.",
 	Long: `The Kabenero CLI is a command line interface for managing the stacks in a Kabanero environment to create governed applications for businesses.
 
-Before using the cli please configure the github authorization for the cli service. Steps can be found in the following documentation: https://kabanero.io/docs/ref/general/configuration/github-authorization.html
+Before using the CLI please configure the github authorization for the cli service. Steps can be found in the following documentation: https://kabanero.io/docs/ref/general/configuration/github-authorization.html
 
 
 Complete documentation is available at https://kabanero.io`,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,8 +41,7 @@ func homeDir() string {
 var rootCmd = &cobra.Command{
 	Use:   "kabanero",
 	Short: "This repo defines a command line interface used by the enterprise, solution, or application architect who defines and manages the kabanero stacks that are used by developers to create governed applications for their business.",
-	Long: `**kabanero** is a command line interface for managing the stacks in a Kabanero environment, as well as to on-board the people that will use 
-the environment to build applications.
+	Long: `The Kabenero CLI is a command line interface for managing the stacks in a Kabanero environment to create government applications for their business.
 
 Before using the cli please configure the github authorization for the cli service. Steps can be found in the following documentation: https://kabanero.io/docs/ref/general/configuration/github-authorization.html
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,7 +41,7 @@ func homeDir() string {
 var rootCmd = &cobra.Command{
 	Use:   "kabanero",
 	Short: "This repo defines a command line interface used by the enterprise, solution, or application architect who defines and manages the kabanero stacks that are used by developers to create governed applications for their business.",
-	Long: `The Kabenero CLI is a command line interface for managing the stacks in a Kabanero environment to create government applications for their business.
+	Long: `The Kabenero CLI is a command line interface for managing the stacks in a Kabanero environment to create governed applications for their business.
 
 Before using the cli please configure the github authorization for the cli service. Steps can be found in the following documentation: https://kabanero.io/docs/ref/general/configuration/github-authorization.html
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,7 +43,7 @@ var rootCmd = &cobra.Command{
 	Short: "This repo defines a command line interface used by the enterprise, solution, or application architect who defines and manages the kabanero stacks that are used by developers to create governed applications for their business.",
 	Long: `The Kabenero CLI is a command line interface for managing the stacks in a Kabanero environment to create governed applications for businesses.
 
-Before using the CLI please configure the github authorization for the cli service. Steps can be found in the following documentation: https://kabanero.io/docs/ref/general/configuration/github-authorization.html
+Before using the CLI please configure the github authorization for the CLI service. Steps can be found in the following documentation: https://kabanero.io/docs/ref/general/configuration/github-authorization.html
 
 
 Complete documentation is available at https://kabanero.io`,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,7 +41,7 @@ func homeDir() string {
 var rootCmd = &cobra.Command{
 	Use:   "kabanero",
 	Short: "This repo defines a command line interface used by the enterprise, solution, or application architect who defines and manages the kabanero stacks that are used by developers to create governed applications for their business.",
-	Long: `The Kabenero CLI is a command line interface for managing the stacks in a Kabanero environment to create governed applications for their business.
+	Long: `The Kabenero CLI is a command line interface for managing the stacks in a Kabanero environment to create governed applications for businesses.
 
 Before using the cli please configure the github authorization for the cli service. Steps can be found in the following documentation: https://kabanero.io/docs/ref/general/configuration/github-authorization.html
 


### PR DESCRIPTION
When you run kabcli without any other commands a long summary and how to use instruction set pops up. The initial kab summary wasn't worded the best ( as mentioned in issue #199 ) 
Before:
```
 $ ./kabanero 
**kabanero** is a command line interface for managing the stacks in a Kabanero 
environment, as well as to on-board the people that will use 
the environment to build applications.

Before using the cli please configure the github authorization for the cli service. Steps can be found in the following documentation: https://kabanero.io/docs/ref/general/configuration/github-authorization.html
```
After:

```
$./build/kabanero
The Kabenero CLI is a command line interface for managing the stacks in a Kabanero environment to create governed applications for businesses.

Before using the cli please configure the github authorization for the cli service. Steps can be found in the following documentation: https://kabanero.io/docs/ref/general/configuration/github-authorization.html
```