### PR TITLE
version fix 3, show the cli image text

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/spf13/cobra"
 )
@@ -37,6 +38,8 @@ var versionCmd = &cobra.Command{
 			return nil
 		}
 
+		fmt.Print("kabanero command line service image: ")
+
 		url := getRESTEndpoint("v1/image")
 		resp, err := sendHTTPRequest("GET", url, nil)
 		if err != nil {
@@ -48,7 +51,7 @@ var versionCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		Info.log("kabanero command line service image: ", versionJSON.Image)
+		fmt.Print(versionJSON.Image + "\n")
 		return nil
 	},
 }


### PR DESCRIPTION
after changing most errors to just os.exit out, the version changed to no longer show the text "command line services image: <version>", 
This is a repeat, PR had to close the other one bc a messup was causing travis to fail

Previously with new os.exit being introduced:
```
claudias-mbp kabanero-command-line =>./build/kabanero version
kabanero cli version: 0.1.0
Session expired or your token is invalid. Please try logging in again
```

Now:
```
claudias-mbp kabanero-command-line =>./build/kabanero version
kabanero cli version: 0.1.0
kabanero command line service image: davco01a/kabanero-command-line-services:latest
```
```
claudias-mbp kabanero-command-line =>./build/kabanero version
kabanero cli version: 0.1.0
kabanero command line service image: Login to your kabanero instance
```