### PR TITLE
changes digest check to string to reflect service change

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -37,7 +37,7 @@ type KabStruct struct {
 type StatusStruct struct {
 	Version        string
 	Status         string
-	DigestCheck    bool   `json:"digest check passed"`
+	DigestCheck    string `json:"digest check"`
 	ImageDigest    string `json:"image digest"`
 	KabaneroDigest string `json:"kabanero digest"`
 }
@@ -124,10 +124,10 @@ var listCmd = &cobra.Command{
 			for j := 0; j < len(data.KabStack[i].Status); j++ {
 				nameAndVersion := data.KabStack[i].Name + data.KabStack[i].Status[j].Version
 				if _, found := obsoleteMap[nameAndVersion]; found {
-					fmt.Fprintf(tWriter, "\n%s\t%s\t%s\t%t", data.KabStack[i].Name, data.KabStack[i].Status[j].Version, data.KabStack[i].Status[j].Status+" (obsolete)", data.KabStack[i].Status[j].DigestCheck)
+					fmt.Fprintf(tWriter, "\n%s\t%s\t%s\t%s", data.KabStack[i].Name, data.KabStack[i].Status[j].Version, data.KabStack[i].Status[j].Status+" (obsolete)", data.KabStack[i].Status[j].DigestCheck)
 
 				} else {
-					fmt.Fprintf(tWriter, "\n%s\t%s\t%s\t%t", data.KabStack[i].Name, data.KabStack[i].Status[j].Version, data.KabStack[i].Status[j].Status, data.KabStack[i].Status[j].DigestCheck)
+					fmt.Fprintf(tWriter, "\n%s\t%s\t%s\t%s", data.KabStack[i].Name, data.KabStack[i].Status[j].Version, data.KabStack[i].Status[j].Status, data.KabStack[i].Status[j].DigestCheck)
 				}
 			}
 		}


### PR DESCRIPTION
Command line services changed the digest check pass value to string instead of bool. Just reflecting that change 
see PR: https://github.com/kabanero-io/kabanero-command-line-services/pull/156
