### PR TITLE
Cleans possible http urls

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -38,6 +38,7 @@ type JWTResponse struct {
 
 func parseKabURL(url string) string {
 	url = strings.TrimPrefix(url, "https://")
+	url = strings.TrimPrefix(url, "http://")
 	url = strings.TrimSuffix(url, "/")
 	return url
 }


### PR DESCRIPTION
Previously user could put in the their kabanero instance url with https or without for flexibility. Did not take into account if they provided the url with http, so if they did it would make the sent url `https://http://<kaburl>.` We only do https with the CLI, but for whatever reason that a person would give a url with http, should strip it and still take the url and send it with https

no UI/experience change 