### PR TITLE
Adds a space to status to try to fix how the table looks 

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -127,7 +127,7 @@ var listCmd = &cobra.Command{
 					fmt.Fprintf(tWriter, "\n%s\t%s\t%s\t%s", data.KabStack[i].Name, data.KabStack[i].Status[j].Version, data.KabStack[i].Status[j].Status+" (obsolete)", data.KabStack[i].Status[j].DigestCheck)
 
 				} else {
-					fmt.Fprintf(tWriter, "\n%s\t%s\t%s\t%s", data.KabStack[i].Name, data.KabStack[i].Status[j].Version, data.KabStack[i].Status[j].Status, data.KabStack[i].Status[j].DigestCheck)
+					fmt.Fprintf(tWriter, "\n%s\t%s\t%s\t%s", data.KabStack[i].Name, data.KabStack[i].Status[j].Version, data.KabStack[i].Status[j].Status+" ", data.KabStack[i].Status[j].DigestCheck)
 				}
 			}
 		}


### PR DESCRIPTION
With the new digest column, when a stack is set to inactive it is just enough letters that the table doesn't auto space out. So I added a space to the status column, only know it spaces it out for an entire tab's width so its a little stretched out. Sort of temporary soln 

before:
```
Kabanero Instance Stacks 	Version	Status	Valid Digest
-------------------------	-------	------	------------
java-microprofile		0.2.26	inactiveunknown
java-openliberty		0.2.3	active	matched
java-spring-boot2		0.3.28	active	matched
nodejs				0.3.3	active	matched
nodejs-express			0.2.10	active	matched
```

after: 
```
Kabanero Instance Stacks 	Version	Status		Valid Digest
-------------------------	-------	------		------------
java-microprofile		0.2.26	inactive 	unknown
java-openliberty		0.2.3	active 		matched
java-spring-boot2		0.3.28	active 		matched
nodejs				0.3.3	active 		matched
nodejs-express			0.2.10	active 		matched
```
little easier to see screenshot
![image (1)](https://user-images.githubusercontent.com/14955890/79489103-d0c60500-7fe8-11ea-80d1-e94a8c12f557.png)
