### PR TITLE
adds password option to pass in in CLI login

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -182,7 +182,6 @@ func init() {
 	loginCmd.Flags().StringP("username", "u", "", "github username")
 	_ = loginCmd.MarkFlagRequired("username")
 	loginCmd.Flags().StringP("password", "p", "", "github password/PAT. If no password is provided, prompt will appear")
-	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command
 	// and all subcommands, e.g.:

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -31,10 +31,6 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-var (
-	password string
-)
-
 type JWTResponse struct {
 	JWT     string
 	Message string
@@ -95,6 +91,8 @@ var loginCmd = &cobra.Command{
 		var err error
 
 		username, _ := cmd.Flags().GetString("username")
+		password, _ := cmd.Flags().GetString("password")
+
 		if password == "" {
 			fmt.Printf("Password:")
 			bytePwd, err := terminal.ReadPassword(int(syscall.Stdin))
@@ -183,7 +181,7 @@ func init() {
 	rootCmd.AddCommand(loginCmd)
 	loginCmd.Flags().StringP("username", "u", "", "github username")
 	_ = loginCmd.MarkFlagRequired("username")
-	loginCmd.Flags().StringVar(&password, "password", "", "github password/PAT")
+	loginCmd.Flags().StringP("password", "p", "", "github password/PAT. If no password is provided, prompt will appear")
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -31,6 +31,10 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
+var (
+	password string
+)
+
 type JWTResponse struct {
 	JWT     string
 	Message string
@@ -91,13 +95,15 @@ var loginCmd = &cobra.Command{
 		var err error
 
 		username, _ := cmd.Flags().GetString("username")
-		fmt.Printf("Password:")
-		bytePwd, err := terminal.ReadPassword(int(syscall.Stdin))
-		if err != nil {
-			return err
+		if password == "" {
+			fmt.Printf("Password:")
+			bytePwd, err := terminal.ReadPassword(int(syscall.Stdin))
+			if err != nil {
+				return err
+			}
+			password = strings.TrimSpace(string(bytePwd))
+			fmt.Println()
 		}
-		password := strings.TrimSpace(string(bytePwd))
-		fmt.Println()
 
 		var kabLoginURL string
 
@@ -177,6 +183,7 @@ func init() {
 	rootCmd.AddCommand(loginCmd)
 	loginCmd.Flags().StringP("username", "u", "", "github username")
 	_ = loginCmd.MarkFlagRequired("username")
+	loginCmd.Flags().StringVar(&password, "password", "", "github password/PAT")
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command


### PR DESCRIPTION
password can now be passed in again on login instead of just a prompt

before:
```  
  -h, --help              help for login
  -u, --username string   github username

```

after:
```
  -h, --help              help for login
  -p, --password string   github password/PAT. If no password is provided, prompt will appear
  -u, --username string   github username
```